### PR TITLE
Update forum URL

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -143,6 +143,6 @@ Contact/Support
 The forum is the recommended method of contacting the team with technical
 issues.
 
-Forum: <http://pkp.sfu.ca/support/forum/>
+Forum: <https://forum.pkp.sfu.ca/>
 Bugs: <http://pkp.sfu.ca/bugzilla/>
 Email: <pkp.contact@gmail.com>


### PR DESCRIPTION
Plus `Bugs: <http://pkp.sfu.ca/bugzilla/>` needs an update. It is broken, up to now.