### PR TITLE
fixes errors in MysqlIndexPlugin and TinyMCEPlugin

### DIFF
--- a/plugins/generic/mysqlIndex/MysqlIndexPlugin.inc.php
+++ b/plugins/generic/mysqlIndex/MysqlIndexPlugin.inc.php
@@ -96,8 +96,7 @@ class MysqlIndexPlugin extends GenericPlugin {
 	 * Get a list of available management verbs for this plugin
 	 * @return array
 	 */
-	function getManagementVerbs() {
-		$verbs = array();
+	function getManagementVerbs($verbs = array()) {
 		if ($this->getEnabled()) {
 			$verbs[] = array('adminCrosswalks', __('plugins.generic.mysqlIndex.crosswalks'));
 		}

--- a/plugins/generic/tinymce/TinyMCEPlugin.inc.php
+++ b/plugins/generic/tinymce/TinyMCEPlugin.inc.php
@@ -166,8 +166,7 @@ class TinyMCEPlugin extends GenericPlugin {
 	 * Get a list of available management verbs for this plugin
 	 * @return array
 	 */
-	function getManagementVerbs() {
-		$verbs = array();
+	function getManagementVerbs($verbs = array()) {
 		if ($this->isMCEInstalled()) $verbs = parent::getManagementVerbs();
 		return $verbs;
 	}


### PR DESCRIPTION
## Setup details:
PHP 7.2.14
MariaDB 10.2.14
Running on OSX

## To reproduce:

1. Clone blank repo and checkout ohs-stable-2_3 branch
2. Run `git submodule update —init —recursive`
3. Copy an existing config.inc.php document using the mysqli driver and connect to an existing database
4. Run `php -S localhost:3000`  to start the server and connect to `localhost:3000` in your browser

At the top of the browser window you should see:

```
harvester2 has produced an error Message: WARNING: Declaration of TinyMCEPlugin::getManagementVerbs() should be compatible with GenericPlugin::getManagementVerbs($verbs = Array) In file: /Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/TinyMCEPlugin.inc.php At line: 23 Stacktrace: File: /Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/TinyMCEPlugin.inc.php line 23 Function: PKPApplication->errorHandler(2, "Declaration of TinyMCEPlugin::getManagementVerbs() should be compatible with GenericPlugin::getManagementVerbs($verbs = Array)", "/Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/TinyMCEPlugin.inc.php", 23, Array(10)) File: /Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/index.php line 21 Function: require_once("/Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/TinyMCEPlugin.inc.php") File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/plugins/PluginRegistry.inc.php line 104 Function: include("/Users/jemisonf/code/harvester-blank/plugins/generic/tinymce/index.php") File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/core/Dispatcher.inc.php line 126 Function: PluginRegistry::loadCategory("generic", True) File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/core/PKPApplication.inc.php line 176 Function: Dispatcher->dispatch(Object(Request)) File: /Users/jemisonf/code/harvester-blank/index.php line 65 Function: PKPApplication->execute() Server info: OS: Darwin PHP Version: 7.2.14 Apache Version: N/A DB Driver: mysqli DB server version: 10.2.14-MariaDB
harvester2 has produced an error Message: WARNING: Declaration of MysqlIndexPlugin::getManagementVerbs() should be compatible with GenericPlugin::getManagementVerbs($verbs = Array) In file: /Users/jemisonf/code/harvester-blank/plugins/generic/mysqlIndex/MysqlIndexPlugin.inc.php At line: 0 Stacktrace: File: /Users/jemisonf/code/harvester-blank/plugins/generic/mysqlIndex/index.php line 21 Function: PKPApplication->errorHandler(2, "Declaration of MysqlIndexPlugin::getManagementVerbs() should be compatible with GenericPlugin::getManagementVerbs($verbs = Array)", "/Users/jemisonf/code/harvester-blank/plugins/generic/mysqlIndex/MysqlIndexPlugin.inc.php", 0, Array(11)) File: /Users/jemisonf/code/harvester-blank/plugins/generic/mysqlIndex/index.php line 21 Function: require_once() File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/plugins/PluginRegistry.inc.php line 104 Function: include("/Users/jemisonf/code/harvester-blank/plugins/generic/mysqlIndex/index.php") File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/core/Dispatcher.inc.php line 126 Function: PluginRegistry::loadCategory("generic", True) File: /Users/jemisonf/code/harvester-blank/lib/pkp/classes/core/PKPApplication.inc.php line 176 Function: Dispatcher->dispatch(Object(Request)) File: /Users/jemisonf/code/harvester-blank/index.php line 65 Function: PKPApplication->execute() Server info: OS: Darwin PHP Version: 7.2.14 Apache Version: N/A DB Driver: mysqli DB server version: 10.2.14-MariaDB
```

## Changes

In `lib/pkp/classes/plugins/GenericPlugin.inc.php`, it looks like the function definition of `getManagementVerbs` has changed from:
```php
function getManagementVerbs()
```

to 

```php
function getManagementVerbs($verbs = array())
```

But the function definitions in `plugins/generic/mysqlIndex/MySqlIndexPlugin.inc.php` and `plugins/generic/tinymce/TinyMCEPlugin.inc.php` have not, triggering the error when run. This PR updates the code in those files to reflect the changes in the base plugin class.